### PR TITLE
Add setup.sh to .gitignore (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ local_env/*
 playground/*
 *.sqlite3
 tasks/
+setup.sh


### PR DESCRIPTION
**Title:** "Add setup.sh to .gitignore (#114)"

**Description:**

This PR addresses issue #114.

**Problem:**
The setup.sh file is not currently included in the .gitignore, and therefore shows up as an untracked file when running git status. This could potentially lead to the file being committed inadvertently, exposing sensitive information such as API keys.

**Solution:**
This PR adds setup.sh to the .gitignore file, preventing Git from tracking it.

**Testing:**
After adding setup.sh to .gitignore and running git status, the setup.sh file no longer shows up as an untracked file.