### PR TITLE
Fix: Resolve Discrepancy in Sphinx Dependency Names

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
-sphinx-panels
-sphinx-rtd-dark-mode==1.2.4
+sphinx # Necessary on Windows
+sphinx-panels # Used on Linux
+sphinx-rtd-dark-mode==1.2.4 # Used on Linux
+sphinx_panels # Used on Windows
+sphinx_rtd_dark_mode # Used on Windows


### PR DESCRIPTION
This PR addresses an issue (#158) regarding a discrepancy in the naming of certain Sphinx dependencies. The requirements file previously included 'sphinx-panels' and 'sphinx-rtd-dark-mode', but on some platforms, these dependencies are known as 'sphinx_panels' and 'sphinx_rtd_dark_mode' respectively. This PR updates the requirements file to include both versions of each dependency's name to ensure cross-compatibility and avoid potential confusion or errors during the installation process.