### PR TITLE
Change line-length to max-line-length for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ addopts = "-m 'not regression' --ignore=**/sample_modules/* --ignore=scip-python
 markers = ["regression: marks tests as regression tests"]
 
 [tool.black]
-line-length = 79
+max-line-length = 79
 include = '\.pyi?$'
 exclude = '''
 (
@@ -94,7 +94,7 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
-line_length = 79
+line-length = 79
 skip_glob = ["**/sample_code/*"]
 
 [tool.mypy]
@@ -132,4 +132,3 @@ ignore = ["E501", "W503"]
 reportGeneralTypeIssues = true
 reportMissingTypeStubs = false
 useLibraryCodeForTypes = true
-


### PR DESCRIPTION
It seems like there's a potential bug with using black and isort, where isort believes the imports can fit in one line according to the line length limit but black disagrees and breaks them into multiple lines.

This PR changes the black line setting from `line-length = 79` to `max-line-length = 79`. This enforces the PEP 8 style conventions.