### PR TITLE
Small fix for OPENAI_API_KEY in setup

### DIFF
--- a/scripts/.setup.sh.example
+++ b/scripts/.setup.sh.example
@@ -16,7 +16,7 @@ cd -
 
 # Set up .env
 cp ../.env.example ../.env
-OPEN_API_KEY=your_openai_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
 GITHUB_API_KEY=your_github_api_key
 CONVERSATION_DB_PATH="$PWD/conversation_db.sqlite3"
 TASK_DB_PATH="$PWD/task_db.sqlite3"


### PR DESCRIPTION
Quick fix for scripts\.setup.sh.example -> openai api key naming caused me a slight error during setup