### PR TITLE
Add poetry install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Follow these steps to setup the Automata environment
 # Clone the repository
 git clone git@github.com:emrgnt-cmplxty/Automata.git && cd Automata/
 
+# Install dependencies
+poetry install
+
 # Configure the environment and setup files
 automata configure
 ```


### PR DESCRIPTION
Adds instructions to install dependencies by running `poetry install` before running `automata configure`, preventing a hard-to-diagnose command not found error.