### PR TITLE
Add Docker Image Building and Pushing via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: publish
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-hello-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and Push the Docker image
+      run: |
+           docker build . --tag ghcr.io/emrgnt-cmplxty/automata:latest
+           docker push ghcr.io/emrgnt-cmplxty/automata:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: publish
-on: 
+on:
   push:
     branches:
       - main


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow that builds and pushes a Docker image to the GitHub Container Registry (ghcr.io) whenever there are changes pushed to the main branch.

A new GitHub Actions workflow file is added with the following key features:

- Triggers on a push event to the main branch.
- Logs in to the GitHub Container Registry.
- Builds a Docker image based on our Dockerfile.
- Pushes the Docker image to the GitHub Container Registry.
- The Docker image is tagged as ghcr.io/emrgnt-cmplxty/automata:latest. This will allow anyone to pull the latest version of our project as a Docker image from the GitHub Container Registry using this tag.

This update will streamline our deployment processes, as anyone will be able to pull the latest Docker image of our project directly from ghcr.io, ensuring they always have the most recent, stable version of our project.