### PR TITLE
Update github_client to find correct path to Automata

### DIFF
--- a/automata/singletons/github_client.py
+++ b/automata/singletons/github_client.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional
 
@@ -73,7 +74,9 @@ class GitHubClient(RepositoryClient, metaclass=Singleton):
     ) -> None:
         self.access_token = access_token
         self.client = Github(access_token)
-        self.remote_name = remote_name
+        self.remote_name = os.getenv(
+            "REPOSITORY_NAME", "emrgnt-cmplxty/automata"
+        )
         self.repo = self.client.get_repo(self.remote_name)
 
         self.primary_branch = primary_branch

--- a/tests/unit/github/test_github_client.py
+++ b/tests/unit/github/test_github_client.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 import responses
 
@@ -13,7 +15,9 @@ GITHUB_REQUEST_JSON = {
 
 
 @responses.activate
-def test_create_issue():
+@patch("os.getenv")
+def test_create_issue(mock_getenv):
+    mock_getenv.return_value = "user/repo"
     responses.add(
         responses.GET,
         GITHUB_REQUEST_BASE,


### PR DESCRIPTION
This PR addresses an issue encountered when running automata, where users who did not own the repository would encountered a github.GithubException.UnknownObjectException: 404 {"message": "Not Found"} error.

This was a result of the repository being found from the user's credentials. To fix this error, this code is refactored to use an environment variable to find the correct repository path.