### PR TITLE
Introduce logging and CLI bug fix

### DIFF
--- a/automata/cli/cli_utils.py
+++ b/automata/cli/cli_utils.py
@@ -19,9 +19,12 @@ def initialize_py_module_loader(
     *args: Any,
     project_root_fpath: Optional[str] = None,
     project_name: Optional[str] = None,
-    project_project_name: Optional[str] = None
+    project_project_name: Optional[str] = None,
+    **kwargs: Any
 ) -> None:
     """Initializes the py_module_loader with the specified project name and root file path."""
+
+    kwargs.pop("log_level", None)
 
     root_path = project_root_fpath or get_root_fpath()
     project_name = project_project_name or project_name or "automata"

--- a/automata/cli/commands.py
+++ b/automata/cli/commands.py
@@ -129,7 +129,7 @@ def run_code_embedding(ctx: click.Context, *args, **kwargs) -> None:
 
     from automata.cli.scripts.run_code_embedding import main
 
-    reconfigure_logging(kwargs.get("log-level", "DEBUG"))
+    reconfigure_logging(kwargs.get("log-level", "INFO"))
     logger.debug("Calling run_code_embedding")
     main(**kwargs)
 
@@ -154,7 +154,7 @@ def run_doc_embedding(
 
     from automata.cli.scripts.run_doc_embedding import main
 
-    reconfigure_logging(kwargs.get("log-level", "DEBUG"))
+    reconfigure_logging(kwargs.get("log-level", "INFO"))
     logger.info("Calling run_doc_embedding")
 
     result = main(overwrite=overwrite, *args, **kwargs)

--- a/automata/cli/env_operations.py
+++ b/automata/cli/env_operations.py
@@ -152,7 +152,7 @@ def update_graph_type(dotenv_path: str, graph_type: str) -> None:
     """Updates the type in the local environment."""
 
     replace_key(dotenv_path, "GRAPH_TYPE", graph_type)
-    log_cli_output(f"The graph type has been updated to {type}.")
+    log_cli_output(f"The graph type has been updated to {graph_type}.")
 
 
 def delete_key_value(dotenv_path: str, key: str) -> None:

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -81,7 +81,7 @@ def test_cli_run_code_embedding():
         )
 
         assert result.exit_code == 0
-        mock_reconfigure_logging.assert_called_once_with("DEBUG")
+        mock_reconfigure_logging.assert_called_once_with("INFO")
         mock_main.assert_called_once()
 
 
@@ -103,7 +103,7 @@ def test_cli_run_doc_embedding():
         )
 
         assert result.exit_code == 0
-        mock_reconfigure_logging.assert_called_once_with("DEBUG")
+        mock_reconfigure_logging.assert_called_once_with("INFO")
         assert mock_main.called
 
 


### PR DESCRIPTION
Fixes two bugs:
1. A log level kwarg was being passed into initialize_py_module_loader from the logger definition, causing an error. This handles that kwarg by removing it in the initialize_py_module_loader, since the log level is set in the CLI command that is calling it, anyways.
2. The way that graph type was being handled changed, resulting in the CLI not printing `The graph type has been updated to <class 'type'>.` rather than `The graph type has been updated to dynamic.`
