### PR TITLE
Generate subgraph from shell script

### DIFF
--- a/automata/cli/scripts/run_code_embedding.py
+++ b/automata/cli/scripts/run_code_embedding.py
@@ -97,6 +97,7 @@ def main(*args, **kwargs) -> str:
         **kwargs
     )
     filtered_symbols = collect_symbols(symbol_graph)
+    dependency_factory.create_subgraph()
     process_embeddings(symbol_code_embedding_handler, filtered_symbols)
 
     return "Success"


### PR DESCRIPTION
Generates the subgraph pickle when running the regenerate_local_indices.sh script.