### PR TITLE
Update submodule hook to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
         ignore = all # necessary to avoid issues from modified package-lock.json
 [submodule "automata-embedding-data"]
 	path = automata-embedding-data
-	url = git@github.com:emrgnt-cmplxty/automata-embedding-data.git
+	url = https://github.com/emrgnt-cmplxty/automata-embedding-data.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /automata
 RUN apt-get update && apt-get install -y gcc g++ curl git
 RUN pip install --no-cache-dir poetry
 
-# Clone the repository
-RUN git clone https://github.com/emrgnt-cmplxty/automata.git .
+# Copy the current directory contents (root of the project) into the container at /automata
+COPY . .
 
 # Initialize and update submodules
 RUN git submodule update --init --recursive


### PR DESCRIPTION
The Docker build was failing because one of the submodules was linked over ssh. This PR corrects that, and reintroduces copying the directory over cloning, as this was not an issue before. 