### PR TITLE
Move install-indexing inside of shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,15 @@ RUN poetry install
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs
 
-# Install dependencies and run indexing on the local codebase
-RUN poetry run automata install-indexing
-
 # Create a script that will be run when the container is started
 RUN echo "#!/bin/bash\n\
+# Configure the environment and setup files\n\
 poetry run automata configure --GITHUB_API_KEY=\$GITHUB_API_KEY --OPENAI_API_KEY=\$OPENAI_API_KEY\n\
+# Install dependencies and run indexing on the local codebase\n\
+poetry run automata install-indexing\n\
+# Refresh the code embeddings (after making local changes)\n\
 poetry run automata run-code-embedding\n\
+# Refresh the documentation + embeddings\n\
 poetry run automata run-doc-embedding --embedding-level=2\n\
 exec \"\$@\"" > entrypoint.sh
 RUN chmod +x entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,9 @@ RUN apt-get install -y nodejs
 
 # Create a script that will be run when the container is started
 RUN echo "#!/bin/bash\n\
-# Configure the environment and setup files\n\
 poetry run automata configure --GITHUB_API_KEY=\$GITHUB_API_KEY --OPENAI_API_KEY=\$OPENAI_API_KEY\n\
-# Install dependencies and run indexing on the local codebase\n\
 poetry run automata install-indexing\n\
-# Refresh the code embeddings (after making local changes)\n\
 poetry run automata run-code-embedding\n\
-# Refresh the documentation + embeddings\n\
 poetry run automata run-doc-embedding --embedding-level=2\n\
 exec \"\$@\"" > entrypoint.sh
 RUN chmod +x entrypoint.sh


### PR DESCRIPTION
Was failing due to the execution environment. While it would be nice if the dynamic graph were already built in the image, I don't think this functionality is vital and can be done at `docker run` time. 