### PR TITLE
Small tweaks to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.10-slim-buster
 WORKDIR /automata
 
 # Install dependencies
-RUN apt-get update && apt-get install -y gcc g++ curl git
+RUN apt-get update && apt-get install -y gcc g++ curl git && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir poetry
 
 # Copy the current directory contents (root of the project) into the container at /automata
@@ -17,12 +17,9 @@ RUN git submodule update --init --recursive
 RUN poetry config virtualenvs.create false
 RUN poetry install
 
-# Install Node.js
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
-
 # Create a script that will be run when the container is started
 RUN echo "#!/bin/bash\n\
+set -e\n\
 poetry run automata configure --GITHUB_API_KEY=\$GITHUB_API_KEY --OPENAI_API_KEY=\$OPENAI_API_KEY\n\
 poetry run automata install-indexing\n\
 poetry run automata run-code-embedding\n\


### PR DESCRIPTION
Adds cleanup after `apt get`, removes a potential double Node install, and enforces stopping at the first error when building Automata. This should hopefully allow for better debugging, if not fix why Docker cannot generate indices.