### PR TITLE
Refactor to fix Pytest warnings and improve CI

### DIFF
--- a/automata/experimental/code_parsers/py/context_processing/context_retriever.py
+++ b/automata/experimental/code_parsers/py/context_processing/context_retriever.py
@@ -238,7 +238,7 @@ class PyContextRetriever:
         self,
         symbol: "Symbol",
         ordered_active_components: Dict[ContextComponent, Dict],
-        indent_level=0,
+        indent_level: int = 0,
     ) -> str:
         """
         Process the context of a specified `Symbol`. The caller has the responsibility
@@ -264,7 +264,7 @@ class PyContextRetriever:
                     symbol, ast_object, **kwargs
                 )
             else:
-                logger.warn(
+                logger.warning(
                     f"Warning: {component} is not a valid context component."
                 )
         return context

--- a/automata/singletons/github_client.py
+++ b/automata/singletons/github_client.py
@@ -1,9 +1,14 @@
+"""
+This module provides an interface for interacting with GitHub repositories.
+"""
+
 import os
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional
 
 from git import Git, Repo
 from github import (
+    Auth,
     Github,
     GitRef,
     Issue,
@@ -74,7 +79,7 @@ class GitHubClient(RepositoryClient, metaclass=Singleton):
     ) -> None:
         """Initialize the GitHub manager."""
         self.access_token = access_token
-        self.client = Github(access_token)
+        self.client = Github(auth=Auth.Token(self.access_token))
         repository_name = os.getenv("REPOSITORY_NAME")
         if not repository_name or repository_name == "your_repository_name":
             repository_name = "emrgnt-cmplxty/automata"
@@ -108,7 +113,7 @@ class GitHubClient(RepositoryClient, metaclass=Singleton):
         )
 
     def checkout_branch(
-        self, repo_local_path: str, branch_name: str, b=True
+        self, repo_local_path: str, branch_name: str, b: bool = True
     ) -> None:
         """Checkout a branch in the repository."""
         repo = Repo(repo_local_path)

--- a/automata/tests/conftest.py
+++ b/automata/tests/conftest.py
@@ -513,7 +513,8 @@ def test_tool(request) -> TestTool:
 
 @pytest.mark.tool_name("TestTool")
 @pytest.mark.tool_description("A test tool for testing purposes")
-def test_tool_instantiation(test_tool):
+def test_tool_instantiation(test_tool: TestTool) -> None:
+    """Test that the TestTool class can be instantiated."""
     assert test_tool.name == "TestTool"
     assert test_tool.description == "A test tool for testing purposes"
     assert test_tool.function is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,13 @@ sphinx_panels = "0.6.0" # Used on Windows
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning:jsonspec.*"]
 addopts = "-m 'not regression and not evaluation' --ignore=**/sample_modules/* --ignore=scip-python/ --ignore=local_tasks/"
-markers = ["regression: marks tests as regression tests", "evaluation: mark a test as part of the evaluation suite"]
-    
+markers = [
+    "regression: marks tests as regression tests",
+    "evaluation: mark a test as part of the evaluation suite",
+    "tool_name: description of tool_name marker",
+    "tool_description: description of the tool's functionality",
+    "performance: marks tests as performance tests",
+]    
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Some deprecated features and other warnings were causing a bit of noise in the Pytest logs. This PR fixes those issues and improves the readability of actual errors.