### PR TITLE
Add logic to see if indices are being ran in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN poetry install
 RUN echo "#!/bin/bash\n\
 set -e\n\
 poetry run automata configure --GITHUB_API_KEY=\$GITHUB_API_KEY --OPENAI_API_KEY=\$OPENAI_API_KEY\n\
-poetry run automata install-indexing\n\
+poetry run automata install-indexing --from-docker=TRUE\n\
 poetry run automata run-code-embedding\n\
 poetry run automata run-doc-embedding --embedding-level=2\n\
 exec \"\$@\"" > entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /automata
 
 # Install dependencies
 RUN apt-get update && apt-get install -y gcc g++ curl git && rm -rf /var/lib/apt/lists/*
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
 RUN pip install --no-cache-dir poetry
 
 # Copy the current directory contents (root of the project) into the container at /automata
@@ -29,11 +31,3 @@ RUN chmod +x entrypoint.sh
 
 # Set this script as the entrypoint for the Docker container
 ENTRYPOINT ["./entrypoint.sh"]
-
-# Instructions on how to run the Docker container
-# These instructions will not be executed during the Docker build
-# They are merely here for the user's convenience
-# Run these commands in the terminal to build and run the Docker container:
-# docker run --name automata_container -it --rm -e OPENAI_API_KEY=<your_openai_key> -e GITHUB_API_KEY=<your_github_key> ghcr.io/emrgnt-cmplxty/automata:latest
-# docker stop automata_container
-# docker rm automata_container (in case you run it with other run command that does not include --rm)

--- a/automata/cli/commands.py
+++ b/automata/cli/commands.py
@@ -145,9 +145,15 @@ def configure(
     help="Logging level",
     type=click.Choice(["DEBUG", "INFO", "CLI_OUTPUT"], case_sensitive=False),
 )
+@click.option(
+    "--from-docker",
+    is_flag=True,
+    default=False,
+    help="Signal if the command is coming from Docker",
+)
 @click.pass_context
 def install_indexing(
-    ctx: click.Context, log_level: str, *args, **kwargs
+    ctx: click.Context, log_level: str, from_docker: bool, *args, **kwargs
 ) -> None:
     """Run the install_index script."""
 
@@ -162,7 +168,7 @@ def install_indexing(
     install_indexing()
 
     logger.info("Generating local indices:")
-    generate_local_indices()
+    generate_local_indices(from_docker=from_docker)
 
 
 @common_options

--- a/automata/cli/install_indexing.py
+++ b/automata/cli/install_indexing.py
@@ -81,7 +81,7 @@ def install_indexing() -> None:
         os.chdir(automata_root)
 
 
-def generate_local_indices() -> None:
+def generate_local_indices(from_docker: bool = False) -> None:
     """Generates the local project indices"""
     (
         automata_root,
@@ -110,7 +110,10 @@ def generate_local_indices() -> None:
 
     shutil.copytree(automata_root, project_in_factory, ignore=ignore_dirs)
 
-    commands = install_nvm_and_nodejs("16.10.0")
+    commands = []
+
+    if not from_docker:
+        commands.extend(install_nvm_and_nodejs("16.10.0"))
 
     node_command = " ".join(
         [


### PR DESCRIPTION
Docker installation of NPM is a little finicky—this PR introduces some logic so that we don't reinstall the node 16.10. 