### PR TITLE
Add 501 response logic to Wolfram Alpha tool

### DIFF
--- a/automata/experimental/tools/builders/wolfram_alpha_oracle_builder.py
+++ b/automata/experimental/tools/builders/wolfram_alpha_oracle_builder.py
@@ -27,7 +27,7 @@ class WolframAlphaToolkitBuilder:
             Tool(
                 name="wolfram-alpha-oracle",
                 function=self.query_wolfram_alpha,
-                description="A tool to query the Wolfram Alpha API and retrieve results.",
+                description="A tool to query the Wolfram Alpha API and retrieve results. This tool will often return a very comprehensive reply. If the tool fails, consider trying a simple request. E.g. instead of `Smallest even factor of 1200`, query for `factors of 1200`. Use the phrase `evaluate for x` whenever possible.",
             )
         ]
 


### PR DESCRIPTION
In cases where WA would return something like:

```
Wolfram|Alpha could not understand: Smallest even factor of 1200. 
Things to try instead:
factor of 1200
Smallest even
even 1200
```

We now implement a way for the agent to handle these responses and query with an appropriate string.